### PR TITLE
fix a bug in plot_shareness

### DIFF
--- a/calour/io.py
+++ b/calour/io.py
@@ -420,7 +420,7 @@ def read(data_file, sample_metadata_file=None, feature_metadata_file=None,
 
 
 def read_amplicon(data_file, sample_metadata_file=None,
-                  *, filter_reads, normalize, **kwargs):
+                  *, min_reads, normalize, **kwargs):
     '''Load an amplicon experiment.
 
     Fix taxonomy, normalize reads, and filter low abundance
@@ -431,8 +431,8 @@ def read_amplicon(data_file, sample_metadata_file=None,
     ----------
     sample_metadata_file : None or str (optional)
         None (default) to just use samplenames (no additional metadata).
-    filter_reads : int or None
-        int (default) to remove all samples with less than ``filter_reads``.
+    min_reads : int or None
+        int (default) to remove all samples with less than ``min_reads``.
         ``None`` to not filter
     normalize : int or None
         normalize each sample to the specified reads. ``None`` to not normalize
@@ -453,10 +453,10 @@ def read_amplicon(data_file, sample_metadata_file=None,
     else:
         exp.feature_metadata['taxonomy'] = 'NA'
 
-    if filter_reads is not None:
-        exp.filter_by_data('sum_abundance', cutoff=filter_reads, inplace=True)
+    if min_reads is not None:
+        exp.filter_by_data('sum_abundance', cutoff=min_reads, inplace=True)
     if normalize is not None:
-        exp.normalize(total=normalize, inplace=True)
+        exp.normalize(total=normalize, axis='s', inplace=True)
 
     return exp
 

--- a/calour/plotting.py
+++ b/calour/plotting.py
@@ -162,7 +162,7 @@ def plot_diff_abundance_enrichment(exp, term_type='term', max_show=10, max_len=4
     return fig, enriched
 
 
-def plot_shareness(exp, field=None, step=3, steps=None, iterations=10, alpha=0.5, linewidth=0.7, ax=None):
+def plot_shareness(exp, field=None, steps=None, iterations=10, alpha=0.5, linewidth=0.7, ax=None):
     '''Plot the number of shared features against the number of samples subsampled.
 
     To see if there is a core feature set shared across most of the samples.
@@ -177,12 +177,14 @@ def plot_shareness(exp, field=None, step=3, steps=None, iterations=10, alpha=0.5
     ----------
     field : str
         sample metadata field to group samples
-    step : int
-        step size to compute the shareness
-    steps : iterable of ints
-        steps to compute the shareness. If it is specified, it overrides ``step``.
+    steps : iterable of int
+        the sizes of subsamples to compute the shareness.
     iterations : int
-        repeat the compute multiple times and plot all the iterations
+        repeat the subsampling multiple times and plot all the iterations
+    alpha : float
+        the transparency (1 is most opaque and 0 is most transparent) to plot for each iteration.
+    linewidth : float
+        the linewidth of the plotting lines for each iteration
     ax : matplotlib Axes, optional
         Axes object to draw the plot onto, otherwise uses the current Axes.
 
@@ -196,52 +198,67 @@ def plot_shareness(exp, field=None, step=3, steps=None, iterations=10, alpha=0.5
         from matplotlib import pyplot as plt
         fig, ax = plt.subplots()
 
-    if field is None:
+    # filter out the illegal large values
+    steps = sorted([i for i in steps if i <= exp.shape[0]], reverse=True)
+    logger.debug('steps are filtered and sorted to %r' % steps)
+
+    def plot_lines(data, steps, label):
+        y_sum = np.zeros(len(steps))
         for i in range(iterations):
-            x, y = _compute_frac_nonzero(exp.data, step, steps)
+            x, y = _compute_frac_nonzero(data, steps)
+            y_sum += y
             if i == 0:
-                line, = ax.plot(x, y * 100, alpha=alpha, linewidth=linewidth)
+                line, = ax.plot(x, y, alpha=alpha, linewidth=linewidth)
             else:
-                # use the same color as the first iteration
-                ax.plot(x, y * 100, alpha=alpha, linewidth=linewidth, color=line.get_color())
+                ax.plot(x, y, alpha=alpha, linewidth=linewidth, color=line.get_color())
+        y_ave = y_sum / iterations
+        # plot average of the iterations
+        ax.plot(x, y_ave, linewidth=linewidth * 3, label=label, color=line.get_color())
+
+    if field is None:
+        plot_lines(exp.data, steps, label='all samples')
     else:
         for uniq in exp.sample_metadata[field].unique():
             data = exp.filter_samples(field, uniq).data
-            ys = []
-            for i in range(iterations):
-                x, y = _compute_frac_nonzero(data, step, steps)
-                ys.append(y)
-                if i == 0:
-                    line, = ax.plot(x, y * 100, alpha=alpha, linewidth=linewidth)
-                else:
-                    ax.plot(x, y * 100, alpha=alpha, linewidth=linewidth, color=line.get_color())
-            y_ave = np.array(ys).mean(axis=0)
-            ax.plot(x, y_ave * 100, linewidth=linewidth * 2, label=uniq, color=line.get_color())
+            # this subset may have number of samples smaller than some value in steps
+            steps_i = [i for i in steps if i <= exp.shape[0]]
+            plot_lines(data, steps_i, uniq)
         ax.legend()
+    # because the shareness drops quickly, we plot it in log scale
     ax.set_xscale('log')
     ax.set_xlabel('sample number')
-    ax.set_ylabel('shared features (%)')
+    ax.set_ylabel('fraction of shared features')
     return ax
 
 
-def _compute_frac_nonzero(data, step, steps):
-    '''iteratively compute the fraction of non-zeros in each column after subsampling rows. '''
-    n, features = data.shape
-    if steps is None:
-        steps = [i for i in range(2, n, step)][::-1]
-    else:
-        # filter out the illegal large values
-        steps = sorted([i for i in steps if i < n], reverse=True)
+def _compute_frac_nonzero(data, steps):
+    '''iteratively compute the fraction of non-zeros in each column after subsampling rows.
+
+    Parameters
+    ----------
+    data : 2-d array of numeric
+        sample in row and feature in column
+    steps : iterable of int
+        the sizes of subsamples
+
+    Return
+    ------
+    tuple of 2 lists
+        steps and fractions
+    '''
+    n_samples, n_features = data.shape
+
     shared = []
     for i in steps:
-        data = data[np.random.choice(n, int(i), replace=False), :]
+        data = data[np.random.choice(n_samples, i, replace=False), :]
         x = data > 0
         # the count of samples that have the given feature
-        counts = x.sum(axis=0).data
-        frac = np.sum(counts == i)
-        shared.append(frac)
-        n = data.shape[0]
-    shared = np.array(shared) / features
+        counts = x.sum(axis=0)
+        all_presence = np.sum(counts == i)
+        all_absence = np.sum(counts == 0)
+        # important: remove the features that are all zeros across the subset of samples
+        shared.append(all_presence / (n_features - all_absence))
+        n_samples = data.shape[0]
     return steps, shared
 
 

--- a/calour/sorting.py
+++ b/calour/sorting.py
@@ -134,7 +134,7 @@ def cluster_data(exp, transform=None, axis=1, metric='euclidean', inplace=False,
 
 
 @Experiment._record_sig
-def cluster_features(exp, min_abundance=10, inplace=False, **kwargs):
+def cluster_features(exp, min_abundance=0, inplace=False, **kwargs):
     '''Cluster features.
 
     Cluster is done after filtering of minimal abundance, log
@@ -143,7 +143,7 @@ def cluster_features(exp, min_abundance=10, inplace=False, **kwargs):
     Parameters
     ----------
     min_abundance : Number, optional
-        filter away features less than ``min_abundance`` (10 by default).
+        filter away features less than ``min_abundance``. Default to 0.
     kwargs : dict
         keyword arguments passing to ``cluster_data``
 

--- a/calour/tests/test_amplicon_experiment.py
+++ b/calour/tests/test_amplicon_experiment.py
@@ -23,7 +23,7 @@ class ExperimentTests(Tests):
     def setUp(self):
         super().setUp()
         self.test1 = ca.read_amplicon(self.test1_biom, self.test1_samp,
-                                      filter_reads=1000, normalize=10000)
+                                      min_reads=1000, normalize=10000)
 
     def test_filter_taxonomy(self):
         # default - substring and keep matching

--- a/calour/tests/test_analysis.py
+++ b/calour/tests/test_analysis.py
@@ -22,7 +22,7 @@ class TestAnalysis(Tests):
         self.test1 = ca.read(self.test1_biom, self.test1_samp, normalize=None)
         # load the complex experiment as sparse with normalizing and removing low read samples
         self.complex = ca.read_amplicon(self.timeseries_biom, self.timeseries_samp,
-                                        filter_reads=1000, normalize=10000)
+                                        min_reads=1000, normalize=10000)
 
     def test_diff_abundance(self):
         # set the seed as we are testing random permutations

--- a/calour/tests/test_database.py
+++ b/calour/tests/test_database.py
@@ -24,7 +24,7 @@ class ExperimentTests(Tests):
         super().setUp()
         self.mock_db = MockDatabase()
         self.test1 = ca.read_amplicon(self.test1_biom, self.test1_samp,
-                                      filter_reads=1000, normalize=10000)
+                                      min_reads=1000, normalize=10000)
         self.s1 = 'TACGTATGTCACAAGCGTTATCCGGATTTATTGGGTTTAAAGGGAGCGTAGGCCGTGGATTAAGCGTGTTGTGAAATGTAGACGCTCAACGTCTGAATCGCAGCGCGAACTGGTTCACTTGAGTATGCACAACGTAGGCGGAATTCGTCG'
 
     def test_mock_db(self):

--- a/calour/tests/test_io.py
+++ b/calour/tests/test_io.py
@@ -118,7 +118,7 @@ class IOTests(Tests):
 
     def test_read_amplicon(self):
         # test loading a taxonomy biom table and filtering/normalizing
-        exp = ca.read_amplicon(self.test1_biom, filter_reads=1000, normalize=10000)
+        exp = ca.read_amplicon(self.test1_biom, min_reads=1000, normalize=10000)
         exp2 = ca.read(self.test1_biom, normalize=None)
         exp2.filter_by_data('sum_abundance', cutoff=1000, inplace=True)
         exp2.normalize(inplace=True)
@@ -148,16 +148,16 @@ class IOTests(Tests):
     def test_save_biom(self):
         # NOTE: Currently not testing the save biom hdf with taxonomy
         # as there is a bug there!
-        exp = ca.read_amplicon(self.test1_biom, self.test1_samp, normalize=None, filter_reads=None)
+        exp = ca.read_amplicon(self.test1_biom, self.test1_samp, normalize=None, min_reads=None)
         d = mkdtemp()
         f = join(d, 'test1.save.biom')
         # test the json biom format
         exp.save_biom(f, fmt='hdf5')
-        newexp = ca.read_amplicon(f, self.test1_samp, normalize=None, filter_reads=None)
+        newexp = ca.read_amplicon(f, self.test1_samp, normalize=None, min_reads=None)
         assert_experiment_equal(newexp, exp)
         # test the txt biom format
         exp.save_biom(f, fmt='txt')
-        newexp = ca.read_amplicon(f, self.test1_samp, normalize=None, filter_reads=None)
+        newexp = ca.read_amplicon(f, self.test1_samp, normalize=None, min_reads=None)
         assert_experiment_equal(newexp, exp, ignore_md_fields=['taxonomy'])
         # test the hdf5 biom format with no taxonomy
         exp.save_biom(f, add_metadata=None)

--- a/calour/tests/test_plotting.py
+++ b/calour/tests/test_plotting.py
@@ -15,6 +15,7 @@ from numpy.testing import assert_array_almost_equal
 import calour as ca
 from calour._testing import Tests
 from calour.util import compute_prevalence
+from calour.plotting import _compute_frac_nonzero
 
 
 class PlotTests(Tests):
@@ -85,11 +86,23 @@ class PlotTests(Tests):
         np.random.seed(12345)
         self.test1 = ca.read(self.test1_biom, self.test1_samp, self.test1_feat, normalize=100)
         self.test1.sparse = False
+        print(self.test1.shape)
         ax = self.test1.filter_samples(
             'group', ['1', '2']).plot_shareness(
-                field='group', steps=(2, 10), iterations=2)
+                field='group', steps=(2, 12), iterations=2)
         lines = ax.get_lines()
         self.assertEqual(len(lines), 6)
+
+    def test_compute_frac_nonzero(self):
+        data = np.array([[4, 5, 0, 3, 5, 1, 4, 3],
+                         [0, 2, 1, 0, 5, 3, 1, 5],
+                         [4, 0, 4, 3, 0, 2, 0, 5],
+                         [2, 4, 0, 4, 2, 0, 1, 0],
+                         [3, 3, 5, 3, 1, 0, 0, 1]])
+        np.random.seed(1)
+        steps, frac = _compute_frac_nonzero(data, [5, 3, 2])
+        self.assertListEqual(steps, [5, 3, 2])
+        assert_array_almost_equal(frac, np.array([0, 0.25, 4/7]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
rename "filter_reads" to "min_reads". The original name is confusing to me. I have to check if it filters out samples or reads every time

unset default for `min_abundance` in cluster_features, because it may go unnoticed too easily, which may cause problem if it is not normalized to 10k.