### PR TITLE
fix a bug of colors x/y bars for heatmap

### DIFF
--- a/calour/heatmap/heatmap.py
+++ b/calour/heatmap/heatmap.py
@@ -488,9 +488,9 @@ def plot(exp: Experiment, title=None,
     bary_fields : str or list of str, optional
         column name(s) in sample metadata (barx) / feature metadata (bary). It plots a bar
         for each column. It doesn't plot color bars by default (None)
-    barx_width : float, optional
-    bary_width : float, optional
-        The width of the bars
+    barx_width : float or list of float, optional
+    bary_width : float or list of float, optional
+        The thickness of the each bar. The default thickness usually looks good enough.
     barx_colors : dict, matplotlib.colors.ListedColormap, optional
     bary_colors : dict, matplotlib.colors.ListedColormap, optional
         The colors for each unique values in the column of sample/feature metadata

--- a/calour/util.py
+++ b/calour/util.py
@@ -30,7 +30,7 @@ import configparser
 from types import FunctionType
 from functools import wraps, update_wrapper
 from importlib import import_module
-from collections.abc import Container
+from collections.abc import Sequence
 from logging import getLogger
 from numbers import Real
 from pkg_resources import resource_filename
@@ -362,10 +362,24 @@ def set_log_level(level):
 
 
 def _to_list(x):
-    '''if x is non iterable or string, convert to iterable '''
+    '''if x is non iterable or string, convert to iterable.
+
+    See the expected behavior in the examples below.
+
+    Examples
+    --------
+    >>> _to_list('a')
+    ['a']
+    >>> _to_list({})
+    [{}]
+    >>> _to_list(['a'])
+    ['a']
+    >>> _to_list(set(['a']))
+    [{'a'}]
+    '''
     if isinstance(x, str):
         return [x]
-    if isinstance(x, Container):
+    if isinstance(x, Sequence):
         return x
     return [x]
 


### PR DESCRIPTION
If a dict given to `barx_colors`, the dict was converted to list of
its keys and color info was lost in bar plotting. The problem is that
`_to_list` should convert a dict to a list of dict.