### PR TITLE
modify experiment.py, test_experiment.py, _test.py for pandas.SparseDataFrame and pandas.util.testing are deprecated

### DIFF
--- a/calour/_testing.py
+++ b/calour/_testing.py
@@ -10,7 +10,7 @@ from unittest import TestCase
 from os.path import join, dirname, abspath
 import logging
 
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 import numpy.testing as npt
 
 import calour as ca

--- a/calour/experiment.py
+++ b/calour/experiment.py
@@ -378,8 +378,7 @@ class Experiment:
 
         if self.sparse:
             # create list of sparse rows
-            sr = [pd.SparseSeries(self.data[i, :].toarray().ravel(), fill_value=0) for i in np.arange(self.data.shape[0])]
-            df = pd.SparseDataFrame(sr, index=ind, columns=cols)
+            df = pd.DataFrame.sparse.from_spmatrix(self.data, index=ind, columns=cols)
         else:
             df = pd.DataFrame(self.data, index=ind, columns=cols, copy=True)
         return df

--- a/calour/tests/test_experiment.py
+++ b/calour/tests/test_experiment.py
@@ -12,7 +12,7 @@ from copy import copy, deepcopy
 import numpy as np
 import pandas as pd
 import numpy.testing as npt
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 from scipy import sparse
 
 from calour._testing import Tests, assert_experiment_equal
@@ -177,8 +177,8 @@ class ExperimentTests(Tests):
     def test_to_pandas_sparse(self):
         df = self.test1.to_pandas(sparse=True)
         data = self.test1.get_data(sparse=False)
-        self.assertIsInstance(df, pd.SparseDataFrame)
-        npt.assert_array_almost_equal(df.to_dense().values, data)
+        self.assertTrue(pd.api.types.is_sparse(df.iloc[0, :]))
+        npt.assert_array_almost_equal(df, data)
 
     def test_from_pands(self):
         df = self.test1.to_pandas(sparse=False)


### PR DESCRIPTION
calour/experiment.py: use pandas.DataFrame.sparse.from_spmatrix function instead of pandas.SparseDataFrame.
calour/test/test_experiment.py: can not assert a dataframe to SparseDataFrame any longer,  so choose one row in the dataframe to assert if it is sparse form;  use pandas.testing instead of pandas.util.testing.
calour/_test.py: use pandas.testing instead of pandas.util.testing.
