### PR TITLE
make database not installed warn instead of raise error

### DIFF
--- a/calour/calour.config
+++ b/calour/calour.config
@@ -1,12 +1,27 @@
 [dbbact]
 module_name = dbbact_calour.dbbact
 class_name = DBBact
+website = www.dbbact.org
+installation = pip install git+git://github.com/amnona/dbbact-calour
+description = manual annotations about bacterial amplicon sequences
 
 [sponge]
 module_name = spongeworld_calour
 class_name = SpongeWorld
+website = www.spongeemp.com/main
+installation = pip install git+git://github.com/amnona/spongeworld-calour
+description = automatic annotations from the sea sponge EMP project
 
 [gnps]
 module_name = gnpscalour
 class_name = GNPS
+website = gnps.ucsd.edu/
+installation = pip install git+git://github.com/amnona/gnps-calour
+description = metabolomics analysis using GNPS output file as database
 
+[phenodb]
+module_name = phenocalour
+class_name = Phenotype
+website = github.com/amnona/pheno-calour
+installation = pip install git+git://github.com/amnona/pheno-calour
+description = phenotypes for cultured bacteria

--- a/calour/database.py
+++ b/calour/database.py
@@ -61,7 +61,12 @@ def _get_database_class(dbname, exp=None, config_file_name=None):
             # import the database module
             db_module = importlib.import_module(module_name)
         except ImportError:
-            raise ValueError('Database interface %s not installed. Did you do pip install for it?' % module_name)
+            module_website = get_config_value('website', section=dbname, config_file_name=config_file_name)
+            module_installation = get_config_value('installation', section=dbname, config_file_name=config_file_name)
+            logger.warning('Database interface %s not installed.\nSkipping.\n'
+                           'You can install the database using:\n%s\n'
+                           'For details see: %s' % (module_name, module_installation, module_website))
+            return None
         # get the class
         DBClass = getattr(db_module, class_name)
         cdb = DBClass(exp)
@@ -76,8 +81,9 @@ def _get_database_class(dbname, exp=None, config_file_name=None):
             databases.append(csection)
     if len(databases) == 0:
         raise ValueError('calour config file %s does not contain any database sections.' % get_config_file())
-    raise ValueError('Database %s not found in config file (%s).\n'
-                     'Currently contains the databases: %s' % (dbname, get_config_file(), databases))
+    logger.warning('Database %s not found in config file (%s).\nSkipping.\n'
+                   'Current databases in config file: %s' % (dbname, get_config_file(), databases))
+    return None
 
 
 def add_terms_to_features(exp: Experiment, dbname, use_term_list=None, field_name='common_term', term_type=None, ignore_exp=None, **kwargs):

--- a/calour/database.py
+++ b/calour/database.py
@@ -80,7 +80,8 @@ def _get_database_class(dbname, exp=None, config_file_name=None):
         if class_name is not None and module_name is not None:
             databases.append(csection)
     if len(databases) == 0:
-        raise ValueError('calour config file %s does not contain any database sections.' % get_config_file())
+        logger.warning('calour config file %s does not contain any database sections. Skipping' % get_config_file())
+        return None
     logger.warning('Database %s not found in config file (%s).\nSkipping.\n'
                    'Current databases in config file: %s' % (dbname, get_config_file(), databases))
     return None

--- a/calour/heatmap/heatmap.py
+++ b/calour/heatmap/heatmap.py
@@ -64,6 +64,8 @@ def _create_plot_gui(exp, gui='cli', databases=('dbbact',), tree_size=0):
     # link gui with the databases requested
     for cdatabase in databases:
         cdb = _get_database_class(cdatabase, exp=exp)
+        if cdb is None:
+            continue
         gui_obj.databases.append(cdb)
         # select the database for use with the annotate button
         if cdb.annotatable:

--- a/calour/tests/test_database.py
+++ b/calour/tests/test_database.py
@@ -53,8 +53,11 @@ class ExperimentTests(Tests):
         calour.util.set_config_value('module_name', 'calour.tests.mock_database', section='testdb', config_file_name=f)
         db = _get_database_class('testdb', config_file_name=f)
         self.assertEqual(db.database_name, 'mock_db')
-        with self.assertRaises(ValueError):
-            _get_database_class('mock')
+
+        # test None results if database does not exist in config file
+        res = _get_database_class('mock')
+        self.assertEqual(res, None)
+
         shutil.rmtree(d)
 
 


### PR DESCRIPTION
Instead of raising an error, just warn the user and provide database interface installation instructions.

* Added installation, website and description to each database section in the calour.config file
* Added phenodb to config file

