### PR TITLE
Dbbact metadata

### DIFF
--- a/calour/amplicon_experiment.py
+++ b/calour/amplicon_experiment.py
@@ -52,6 +52,9 @@ class AmpliconExperiment(Experiment):
     sparse : bool
         store the data array in :class:`scipy.sparse.csr_matrix`
         or :class:`numpy.ndarray`
+    databases: iterable of str, optional
+        database interface names to show by default in heatmap() function
+        by default use 'dbbact'
 
     Attributes
     ----------
@@ -78,7 +81,7 @@ class AmpliconExperiment(Experiment):
     --------
     Experiment
     '''
-    def __init__(self, *args, databases={'dbbact': {}}, **kwargs):
+    def __init__(self, *args, databases=('dbbact'), **kwargs):
         super().__init__(*args, databases=databases, **kwargs)
 
     def heatmap(self, *args, **kwargs):

--- a/calour/amplicon_experiment.py
+++ b/calour/amplicon_experiment.py
@@ -70,15 +70,16 @@ class AmpliconExperiment(Experiment):
         information about the experiment (data md5, filenames, etc.)
     description : str
         name of the experiment
-    databases : iterable of str
-        databases for fetching and entering feature annotations
+    databases : dict
+        keys are the database names (i.e. 'dbbact' / 'gnps')
+        values are the database specific data for the experiment (i.e. annotations for dbbact)
 
     See Also
     --------
     Experiment
     '''
-    def __init__(self, *args, databases=('dbbact',), **kwargs):
-        super().__init__(*args, databases=('dbbact',), **kwargs)
+    def __init__(self, *args, databases={'dbbact': {}}, **kwargs):
+        super().__init__(*args, databases=databases, **kwargs)
 
     def heatmap(self, *args, **kwargs):
         '''Plot a heatmap for the amplicon experiment.

--- a/calour/amplicon_experiment.py
+++ b/calour/amplicon_experiment.py
@@ -81,7 +81,7 @@ class AmpliconExperiment(Experiment):
     --------
     Experiment
     '''
-    def __init__(self, *args, databases=('dbbact'), **kwargs):
+    def __init__(self, *args, databases=('dbbact',), **kwargs):
         super().__init__(*args, databases=databases, **kwargs)
 
     def heatmap(self, *args, **kwargs):

--- a/calour/calour.config
+++ b/calour/calour.config
@@ -4,6 +4,7 @@ class_name = DBBact
 website = www.dbbact.org
 installation = pip install git+git://github.com/amnona/dbbact-calour
 description = manual annotations about bacterial amplicon sequences
+min_version = 2020.0709
 
 [sponge]
 module_name = spongeworld_calour

--- a/calour/database.py
+++ b/calour/database.py
@@ -56,10 +56,15 @@ def _get_database_class(dbname, exp=None, config_file_name=None):
     '''
     class_name = get_config_value('class_name', section=dbname, config_file_name=config_file_name)
     module_name = get_config_value('module_name', section=dbname, config_file_name=config_file_name)
+    min_version = float(get_config_value('min_version', section=dbname, config_file_name=config_file_name, fallback='0.0'))
+
     if class_name is not None and module_name is not None:
         try:
             # import the database module
             db_module = importlib.import_module(module_name)
+            if min_version > 0:
+                if db_module.version < min_version:
+                    logger.warning('Please update database %s module. Version (%f) not supported (minimal version %f)' % (dbname, db_module.version, min_version))
         except ImportError:
             module_website = get_config_value('website', section=dbname, config_file_name=config_file_name)
             module_installation = get_config_value('installation', section=dbname, config_file_name=config_file_name)

--- a/calour/database.py
+++ b/calour/database.py
@@ -57,16 +57,13 @@ def _get_database_class(dbname, exp=None, config_file_name=None):
     class_name = get_config_value('class_name', section=dbname, config_file_name=config_file_name)
     module_name = get_config_value('module_name', section=dbname, config_file_name=config_file_name)
     min_version = float(get_config_value('min_version', section=dbname, config_file_name=config_file_name, fallback='0.0'))
+    module_website = get_config_value('website', section=dbname, config_file_name=config_file_name, fallback='NA')
 
     if class_name is not None and module_name is not None:
         try:
             # import the database module
             db_module = importlib.import_module(module_name)
-            if min_version > 0:
-                if db_module.version < min_version:
-                    logger.warning('Please update database %s module. Version (%f) not supported (minimal version %f)' % (dbname, db_module.version, min_version))
         except ImportError:
-            module_website = get_config_value('website', section=dbname, config_file_name=config_file_name)
             module_installation = get_config_value('installation', section=dbname, config_file_name=config_file_name)
             logger.warning('Database interface %s not installed.\nSkipping.\n'
                            'You can install the database using:\n%s\n'
@@ -75,6 +72,11 @@ def _get_database_class(dbname, exp=None, config_file_name=None):
         # get the class
         DBClass = getattr(db_module, class_name)
         cdb = DBClass(exp)
+        # test if database version is compatible
+        if min_version > 0:
+            db_version = cdb.version()
+            if db_version < min_version:
+                logger.warning('Please update %s database module. Current version (%f) not supported (minimal version %f).\nFor details see %s' % (dbname, db_version, min_version, module_website))
         return cdb
     # not found, so print available database names
     databases = []

--- a/calour/experiment.py
+++ b/calour/experiment.py
@@ -76,7 +76,7 @@ class Experiment:
         information about the experiment (data md5, filenames, etc.)
     description : str
         a short description of the experiment
-    databases : dict
+    databases : defaultdict(dict)
         keys are the database names (i.e. 'dbbact' / 'gnps')
         values are the database specific data for the experiment (i.e. annotations for dbbact)
 
@@ -105,7 +105,7 @@ class Experiment:
         self.sparse = sparse
 
         # the database local specific data (to use for feature information)
-        self.databases = databases
+        self.databases = defaultdict(dict, databases)
 
     def validate(self):
         '''Validate the Experiment object.

--- a/calour/experiment.py
+++ b/calour/experiment.py
@@ -85,7 +85,7 @@ class Experiment:
     AmpliconExperiment
     MS1Experiment
     '''
-    def __init__(self, data, sample_metadata, feature_metadata=None, databases={},
+    def __init__(self, data, sample_metadata, feature_metadata=None, databases=(),
                  info=None, description='', sparse=True):
         self.data = data
         self.sample_metadata = sample_metadata
@@ -105,7 +105,9 @@ class Experiment:
         self.sparse = sparse
 
         # the database local specific data (to use for feature information)
-        self.databases = defaultdict(dict, databases)
+        self.databases = defaultdict(dict)
+        for cdatabase in databases:
+            self.databases[cdatabase] = {}
 
     def validate(self):
         '''Validate the Experiment object.

--- a/calour/experiment.py
+++ b/calour/experiment.py
@@ -76,15 +76,16 @@ class Experiment:
         information about the experiment (data md5, filenames, etc.)
     description : str
         a short description of the experiment
-    databases : iterable of str
-        databases for fetching and entering feature annotations
+    databases : dict
+        keys are the database names (i.e. 'dbbact' / 'gnps')
+        values are the database specific data for the experiment (i.e. annotations for dbbact)
 
     See Also
     --------
     AmpliconExperiment
     MS1Experiment
     '''
-    def __init__(self, data, sample_metadata, feature_metadata=None, databases=(),
+    def __init__(self, data, sample_metadata, feature_metadata=None, databases={},
                  info=None, description='', sparse=True):
         self.data = data
         self.sample_metadata = sample_metadata
@@ -103,7 +104,7 @@ class Experiment:
         # flag if data array is sparse (True) or dense (False)
         self.sparse = sparse
 
-        # the default databases to use for feature information
+        # the database local specific data (to use for feature information)
         self.databases = databases
 
     def validate(self):

--- a/calour/experiment.py
+++ b/calour/experiment.py
@@ -55,6 +55,8 @@ class Experiment:
     sparse : bool
         store the data array in :class:`scipy.sparse.csr_matrix`
         or :class:`numpy.ndarray`
+    databases: iterable of str, optional
+        database interface names to show by default in heatmap() function
 
     Attributes
     ----------

--- a/calour/heatmap/heatmap.py
+++ b/calour/heatmap/heatmap.py
@@ -546,7 +546,7 @@ def plot(exp: Experiment, title=None,
     '''
     # set the databases if default requested
     if databases is None:
-        databases = exp.databases
+        databases = list(exp.databases.keys())
 
     if tree is None:
         gui_obj = _create_plot_gui(exp, gui, databases)

--- a/calour/heatmap/plotgui.py
+++ b/calour/heatmap/plotgui.py
@@ -76,7 +76,7 @@ class PlotGUI(ABC):
     ax_legend : matplotlib.axes.Axes
         Axes for the color legend
     databases : list on None, optional
-        the databases to interact with. If None, 
+        the databases to interact with.
 
     Parameters
     ----------

--- a/calour/heatmap/plotgui.py
+++ b/calour/heatmap/plotgui.py
@@ -75,8 +75,8 @@ class PlotGUI(ABC):
         Axes for the dendrogram/tree
     ax_legend : matplotlib.axes.Axes
         Axes for the color legend
-    databases : list
-        the databases to interact with
+    databases : list on None, optional
+        the databases to interact with. If None, 
 
     Parameters
     ----------
@@ -86,7 +86,8 @@ class PlotGUI(ABC):
         the scaling factor for zooming
     scroll_offset : float
         The amount of columns/rows to scroll when arrow key pressed
-    databases : the databases to interact with
+    databases : list of str or None
+        the databases to interact with.
     tree_size : int (>= 0)
         the width of the axes to plot a tree. 7 is a good value to start.
 

--- a/calour/heatmap/plotgui_qt5.py
+++ b/calour/heatmap/plotgui_qt5.py
@@ -26,7 +26,8 @@ class PlotGUI_QT5(PlotGUI):
     figure : ``matplotlib.figure.Figure``
     app : QT5 App created
     app_window : Windows belonging to the QT5 App
-    databases :
+    databases : list of str
+        The databases to interact with
     '''
 
     @ds.with_indent(8)

--- a/calour/tests/mock_database.py
+++ b/calour/tests/mock_database.py
@@ -77,3 +77,8 @@ class MockDatabase(Database):
             for cstr in cterms:
                 feature_terms[cseq].append(cstr)
         return feature_terms
+
+    def version(self):
+        '''return the current database version
+        '''
+        return 2020.0709


### PR DESCRIPTION
Make database interface compatible with the new database metadata structure:
* convert Experiment.databases to defaultdict(dict). i.e. for dbbact data is stored in exp.databases['dbbact']
* add minimal version support to database config file and test it