### PR TITLE
fix mannwhitney warning

### DIFF
--- a/calour/dsfdr.py
+++ b/calour/dsfdr.py
@@ -61,7 +61,7 @@ def stdmeandiff(data, labels):
 def mannwhitney(data, labels):
     group0 = data[:, labels == 0]
     group1 = data[:, labels == 1]
-    tstat = np.array([scipy.stats.mannwhitneyu(group0[i, :], group1[i, :])
+    tstat = np.array([scipy.stats.mannwhitneyu(group0[i, :], group1[i, :], alternative='two-sided')
                       .statistic for i in range(np.shape(data)[0])])
     return tstat
 

--- a/calour/tests/test_dsfdr.py
+++ b/calour/tests/test_dsfdr.py
@@ -82,9 +82,9 @@ class StatisticsTests(TestCase):
     def test_mannwhitney(self):
         res = dsfdr.mannwhitney(self.data, self.labels)
         self.assertEqual(len(res), self.data.shape[0])
-        self.assertEqual(res[0], 0)
+        self.assertEqual(res[0], 16)
         self.assertEqual(res[1], 8)
-        self.assertEqual(res[2], 5.5)
+        self.assertEqual(res[2], 10.5)
 
     def test_kruwallis(self):
         res = dsfdr.kruwallis(self.data2, self.labels2)


### PR DESCRIPTION
Change the mann-whitney statit to use two-sided instead of the previous default None (which is depracated)
