### PR TITLE
Heatmap nan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # calour changelog
 
+## Version 2020.???
+Incompatible changes:
+* Change random_seed to work with numpy.random.default_rng. This may cause different random numbers compared to the old versions using numpy.random.seed().
+* Change parameter names in some functions
+* Rename filter_abundance() to filter_sum(abundance)
+
+New features:
+* Add bad_color parameter to heatmap() and derivative functions
+* Add more methods for MS1Experiment
+* Add q-values (correted p-values) to dsfdr and derivative functions. This is manifested in a new feature_metadata field ("qval") for results of diff_abundance() / correlation()
+* improved GUI for qt5 heatmap database enrichment results.
+
+
+
 ## Version 2020.8.6
 
 * Add `read_qiime2()` function to enable reading of qiime2 feature tables artifacts with the associated representative sequences and taxonomy artifacts (without the need to install qiime2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,27 @@
 # calour changelog
 
-## Version 2020.???
+
+
+
+
+## Version 2020.8.6
+
 Incompatible changes:
 * Change random_seed to work with numpy.random.default_rng. This may cause different random numbers compared to the old versions using numpy.random.seed().
 * Change parameter names in some functions
 * Rename filter_abundance() to filter_sum(abundance)
+* Other backwards incompatible function API changes and code refactoring.
 
 New features:
 * Add bad_color parameter to heatmap() and derivative functions
 * Add more methods for MS1Experiment
 * Add q-values (correted p-values) to dsfdr and derivative functions. This is manifested in a new feature_metadata field ("qval") for results of diff_abundance() / correlation()
 * improved GUI for qt5 heatmap database enrichment results.
-
-
-
-## Version 2020.8.6
-
 * Add `read_qiime2()` function to enable reading of qiime2 feature tables artifacts with the associated representative sequences and taxonomy artifacts (without the need to install qiime2)
 * Add `Experiment.validate()`.
 * Change default color scale in heatmap plot to linear scale for `Experiment` and log scale for `AmpliconExperiment` and `MS1Experiment`.
-* Add adjusted p-value after correlation and differential abundance analyses.
 * Move to pytest for unit tests and doctests.
 * Add new mechanism to register a function to a class as a method automatically. In order for a function to be registerred to a class, it must be a public function and has type hint of the class type for its first function parameter and return value.
-* Other backwards incompatible function API changes and code refactoring.
 * Clean and improve API documentation.
 
 ## Version 2019.5.1

--- a/calour/heatmap/heatmap.py
+++ b/calour/heatmap/heatmap.py
@@ -170,7 +170,7 @@ def heatmap(exp: Experiment, sample_field=None, feature_field=None,
             xticklabel_len=16, yticklabel_len=16,
             xticks_max=10, yticks_max=30,
             norm=None, clim=(None, None), cmap='viridis',
-            rect=None, cax=None, ax=None):
+            rect=None, cax=None, ax=None, bad_color='black'):
     '''Plot a heatmap for the experiment.
 
     Plot a heatmap for the :attr:`.Experiment.data` with features in row
@@ -218,6 +218,8 @@ def heatmap(exp: Experiment, sample_field=None, feature_field=None,
     ax : matplotlib.axes.Axes or None (default), optional
         The axes where the heatmap is plotted. None (default) to create a new figure and
         axes to plot the heatmap
+    bad_color: str or matplotlib color, optional
+        The heatmap color to use for masked / NaN values
 
     Returns
     -------
@@ -304,7 +306,7 @@ def heatmap(exp: Experiment, sample_field=None, feature_field=None,
     if isinstance(cmap, str):
         cmap = plt.get_cmap(cmap)
     # this set cells of zero value.
-    cmap.set_bad('black')
+    cmap.set_bad(bad_color)
 
     # plot the heatmap
     vmin, vmax = clim


### PR DESCRIPTION
Add an option to specify a different color for the colormap.bad_color().
Used to be hard-set in the heatmap() code to 'black'. But sometimes we want a different color for the nans.
While we could use the bad_color set in the colormap parameter, problem is the default bad_color() (at least for viridis) is 'white', which does not look good (since all the 0s are log transformed to nans)

also updated changelog