### PR TITLE
fix debug message in delete sequence from annotation

### DIFF
--- a/calour/heatmap/plotgui_qt5.py
+++ b/calour/heatmap/plotgui_qt5.py
@@ -346,7 +346,7 @@ class ApplicationWindow(QMainWindow):
             return
         data = item.data(QtCore.Qt.UserRole)
         db = data.get('_db_interface', None)
-        logger.debug('Removing %d features from annotation %s' % (features, item.text()))
+        logger.debug('Removing %d features from annotation %s' % (len(features), item.text()))
         err = db.remove_features_from_annotation(features, data)
         if err:
             logger.error('Features not removed from annotation. Error: %s' % err)


### PR DESCRIPTION
fix the debugging message in right_menu_remove_feature
(called when right clicking on a feature and selecting remove from annotation)