### PR TITLE
fix bar_label_kwargs so rotation works

### DIFF
--- a/calour/heatmap/heatmap.py
+++ b/calour/heatmap/heatmap.py
@@ -406,6 +406,10 @@ def _ax_bar(ax, values, colors=None, width=0.3, position=0, label=True, label_kw
         label_kwargs = {}
     kwargs = {'color': 'w', 'weight': 'bold', 'size': 6,
               'ha': 'center', 'va': 'center'}
+    if axis == 0:
+        kwargs['rotation'] = 0
+    else:
+        kwargs['rotation'] = 90
     kwargs.update(label_kwargs)
 
     # convert to string and leave it as empty if it is None
@@ -428,12 +432,10 @@ def _ax_bar(ax, values, colors=None, width=0.3, position=0, label=True, label_kw
                 # plot the color bar along x axis
                 pos = prev - offset, position
                 w, h = i - prev, width
-                rotation = 0
             else:
                 # plot the color bar along y axis
                 pos = position, prev - offset
                 w, h = width, i - prev
-                rotation = 90
             rect = mpatches.Rectangle(
                 pos,               # position
                 w,                 # width (size along x axis)
@@ -448,8 +450,7 @@ def _ax_bar(ax, values, colors=None, width=0.3, position=0, label=True, label_kw
                 cy = ry + rect.get_height() / 2.0
 
                 # add the text in the color bars
-                ax.annotate(value, (cx, cy), rotation=rotation,
-                            **kwargs)
+                ax.annotate(value, (cx, cy), **kwargs)
 
         prev = i
 


### PR DESCRIPTION
Add option for "rotation" parameter in barx_label_kwargs / bary_label_kwargs
(previous implementation it was not possible to change rotation since provided in the function explicitly)