### PR TITLE
make html export use https for obtaining dsj3

### DIFF
--- a/calour/export_html_template.html
+++ b/calour/export_html_template.html
@@ -4,7 +4,7 @@
 <head>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <style>
     .axis path {
       display: none;

--- a/calour/tests/data/export_html_result.html
+++ b/calour/tests/data/export_html_result.html
@@ -4,7 +4,7 @@
 <head>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <style>
     .axis path {
       display: none;


### PR DESCRIPTION
So will work when embedded in https page (such as qiime2 view)