### PR TITLE
Dbbact version

### DIFF
--- a/calour/calour.config
+++ b/calour/calour.config
@@ -4,7 +4,7 @@ class_name = DBBact
 website = www.dbbact.org
 installation = pip install git+git://github.com/amnona/dbbact-calour
 description = manual annotations about bacterial amplicon sequences
-min_version = 2020.0709
+min_version = 1.4
 
 [sponge]
 module_name = spongeworld_calour

--- a/calour/database.py
+++ b/calour/database.py
@@ -27,6 +27,7 @@ import importlib
 
 from .util import get_config_value, get_config_file, get_config_sections
 from .experiment import Experiment
+from packaging import version
 
 logger = getLogger(__name__)
 
@@ -56,7 +57,7 @@ def _get_database_class(dbname, exp=None, config_file_name=None):
     '''
     class_name = get_config_value('class_name', section=dbname, config_file_name=config_file_name)
     module_name = get_config_value('module_name', section=dbname, config_file_name=config_file_name)
-    min_version = float(get_config_value('min_version', section=dbname, config_file_name=config_file_name, fallback='0.0'))
+    min_version = version.parse(get_config_value('min_version', section=dbname, config_file_name=config_file_name, fallback='0.0'))
     module_website = get_config_value('website', section=dbname, config_file_name=config_file_name, fallback='NA')
 
     if class_name is not None and module_name is not None:
@@ -73,10 +74,10 @@ def _get_database_class(dbname, exp=None, config_file_name=None):
         DBClass = getattr(db_module, class_name)
         cdb = DBClass(exp)
         # test if database version is compatible
-        if min_version > 0:
-            db_version = cdb.version()
+        if min_version.major > 0:
+            db_version = version.parse(str(cdb.version()))
             if db_version < min_version:
-                logger.warning('Please update %s database module. Current version (%f) not supported (minimal version %f).\nFor details see %s' % (dbname, db_version, min_version, module_website))
+                logger.warning('Please update %s database module. Current version (%s) not supported (minimal version %s).\nFor details see %s' % (dbname, db_version.public, min_version.public, module_website))
         return cdb
     # not found, so print available database names
     databases = []


### PR DESCRIPTION
Moved dbbact-calour version numbers to semantic versioning (i.e. '1.4.1')
Added support for parsing these version numbers when getting the minimal database version from the calour.config file.
If database version is lower than the recommended version in the calour.config, it displays a warning to the user
Also updated calour.config for the new semantic versioning minimal recommended dbbact-calour version (1.4)