### PR TITLE
fix join_metadata() and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # calour changelog
 
 
-
-
+## Version 2022.7.1
+Bug Fixes:
+* Fix join_metadata() to use axis='s' by default
 
 ## Version 2020.8.6
 

--- a/calour/__init__.py
+++ b/calour/__init__.py
@@ -18,7 +18,7 @@ from .util import set_log_level, register_functions
 
 
 __credits__ = "https://github.com/biocore/calour/graphs/contributors"
-__version__ = "2019.5.1"
+__version__ = "2022.7.1"
 
 __all__ = ['read', 'read_amplicon', 'read_ms', 'read_qiime2',
            'Experiment', 'AmpliconExperiment', 'MS1Experiment',

--- a/calour/manipulation.py
+++ b/calour/manipulation.py
@@ -75,7 +75,7 @@ def chain(exp: Experiment, steps=[], inplace=False, **kwargs) -> Experiment:
 
 
 def join_metadata_fields(exp: Experiment, field1, field2, new_field=None,
-                         axis='s', inplace=True, **kwargs) -> Experiment:
+                         axis=0, inplace=True, **kwargs) -> Experiment:
     '''Join 2 fields in sample or feature metadata into 1.
 
     Parameters


### PR DESCRIPTION
the default should be 0 rather than 's' since the conversion from 's'->0 is performed if the parameter is supplied (not on the default)