### PR TITLE
fix heatmap() inplace colormap modification depracation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Version 2022.7.1
 Bug Fixes:
 * Fix join_metadata() to use axis='s' by default
+* Fix heatmap() to copy the colormap to avoid matplotlib depracation warning (modifying the state of a globally registered colormap)
 
 ## Version 2020.8.6
 

--- a/calour/heatmap/heatmap.py
+++ b/calour/heatmap/heatmap.py
@@ -9,6 +9,7 @@
 from logging import getLogger
 import importlib
 import itertools
+import copy
 
 import matplotlib as mpl
 import matplotlib.patches as mpatches
@@ -304,6 +305,10 @@ def heatmap(exp: Experiment, sample_field=None, feature_field=None,
         cmap = plt.rcParams['image.cmap']
     if isinstance(cmap, str):
         cmap = plt.get_cmap(cmap)
+
+    # copy the colormap so the changes we make are local
+    cmap = copy.copy(cmap)
+
     # this set cells of zero value.
     cmap.set_bad(bad_color)
 


### PR DESCRIPTION
copy the colormap so we don't modify in place (otherwise we get a matplotlib deprecation warning)
