### PR TITLE
fix _read_metadata() to show as warning/info only the summary 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Version 2022.7.1
 Bug Fixes:
 * Fix join_metadata() to use axis='s' by default
+* Fix experiment read functions to show by default only the summary and first 5 samples without data/without metadata
 
 ## Version 2020.8.6
 

--- a/calour/io.py
+++ b/calour/io.py
@@ -314,10 +314,14 @@ def _read_metadata(ids, f, kwargs):
         mid, ids2 = set(metadata.index), set(ids)
         diff = mid - ids2
         if diff:
-            logger.warning('These have metadata but do not have data - dropped (%d): %r' % (len(diff), diff))
+            logger.warning('Found %d samples that have metadata but do not have data. These samples have been dropped.' % len(diff))
+            logger.info('First 5 samples without data: %r' % diff[:5])
+            logger.debug('These have metadata but do not have data - dropped (%d): %r' % (len(diff), diff))
         diff = ids2 - mid
         if diff:
-            logger.warning('These have data but do not have metadata: %r' % diff)
+            logger.warning('Found %d samples that have data but do not have metadata.' % len(diff))
+            logger.info('First 5 samples without metadata: %r' % diff[:5])
+            logger.debug('These have data but do not have metadata: %r' % diff)
         # reorder the id in metadata to align with biom
         # metadata = metadata.loc[ids, ]
 


### PR DESCRIPTION
Instead of giving a warning with all the missing sample data/metadata, show only a summary and first 5 samples without data/metadata.
The full list of problematic samples is available as a debug() level message.
