### PR TITLE
remove normaliztion check warning from filter_by_data()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Version 2022.7.1
 Bug Fixes:
 * Fix join_metadata() to use axis='s' by default
+* Remove normalization check from filter_by_data()
 
 ## Version 2020.8.6
 

--- a/calour/filtering.py
+++ b/calour/filtering.py
@@ -248,8 +248,6 @@ def filter_by_data(exp: Experiment, predicate, axis=1, field=None,
     filter_prevalence
 
     '''
-    if exp.normalized <= 0:
-        logger.warning('Do you forget to normalize your data? It is required before running this function')
     logger.debug('filter_by_data using function %r' % predicate)
 
     if axis == 0:


### PR DESCRIPTION
To prevent the warning when reading an experiment
