### PR TITLE
Mpl37 plot fix and additional type hints for methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # calour changelog
+## Version 2023.4.22
+Bug Fixes:
+* update the Experiment.plot() function so works also with matplotlib > 3.7
 ## Version 2022.9.8
 
 Other changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # calour changelog
+## Version 2022.9.8
 
+Other changes:
+* Add type hints to function return values
 
 ## Version 2022.7.1
 Incompatible changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 Other changes:
 * Add type hints to function return values
+* Create Experiment.info dict and populate with md5s if not provided when creating a new experiment
 
 ## Version 2022.7.1
 Incompatible changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # calour changelog
+
 ## Version 2023.4.22
+
 Bug Fixes:
 * update the Experiment.plot() function so works also with matplotlib > 3.7
+
 ## Version 2022.9.8
 
 Other changes:

--- a/calour/analysis.py
+++ b/calour/analysis.py
@@ -46,7 +46,7 @@ _CALOUR_DIRECTION = '_calour_direction'
 
 @format_docstring(_CALOUR_PVAL, _CALOUR_QVAL, _CALOUR_STAT, _CALOUR_DIRECTION)
 def correlation(exp: Experiment, field, method='spearman', nonzero=False, transform=None,
-                numperm=1000, alpha=0.1, fdr_method='dsfdr', random_seed=None):
+                numperm=1000, alpha=0.1, fdr_method='dsfdr', random_seed=None) -> Experiment:
     '''Find features with correlation to a numeric metadata field.
 
     The permutation based p-values and multiple hypothesis correction is implemented.
@@ -140,7 +140,7 @@ def correlation(exp: Experiment, field, method='spearman', nonzero=False, transf
 
 
 @format_docstring(_CALOUR_PVAL, _CALOUR_QVAL, _CALOUR_STAT, _CALOUR_DIRECTION)
-def diff_abundance(exp: Experiment, field, val1, val2=None, method='meandiff', transform='rankdata', numperm=1000, alpha=0.1, fdr_method='dsfdr', shuffler=None, random_seed=None):
+def diff_abundance(exp: Experiment, field, val1, val2=None, method='meandiff', transform='rankdata', numperm=1000, alpha=0.1, fdr_method='dsfdr', shuffler=None, random_seed=None) -> Experiment:
     '''Differential abundance test between 2 groups of samples for all the features.
 
     It uses permutation based nonparametric test and then applies
@@ -252,7 +252,7 @@ def diff_abundance(exp: Experiment, field, val1, val2=None, method='meandiff', t
     return newexp
 
 
-def diff_abundance_kw(exp: Experiment, field, transform='rankdata', numperm=1000, alpha=0.1, fdr_method='dsfdr', random_seed=None):
+def diff_abundance_kw(exp: Experiment, field, transform='rankdata', numperm=1000, alpha=0.1, fdr_method='dsfdr', random_seed=None) -> Experiment:
     '''Test the differential abundance between multiple sample groups using the Kruskal Wallis test.
 
     It uses permutation based nonparametric test and then applies
@@ -312,7 +312,7 @@ def diff_abundance_kw(exp: Experiment, field, transform='rankdata', numperm=1000
 
 
 @format_docstring(_CALOUR_PVAL, _CALOUR_QVAL, _CALOUR_STAT, _CALOUR_DIRECTION)
-def diff_abundance_paired(exp: Experiment, pair_field, field, val1, val2=None, transform='rankdata', random_seed=None, **kwargs):
+def diff_abundance_paired(exp: Experiment, pair_field, field, val1, val2=None, transform='rankdata', random_seed=None, **kwargs) -> Experiment:
     '''Differential abundance test between 2 groups of samples for all the features.
 
     It uses permutation based nonparametric test and then applies
@@ -407,7 +407,7 @@ def diff_abundance_paired(exp: Experiment, pair_field, field, val1, val2=None, t
     return newexp
 
 
-def _new_experiment_from_pvals(cexp, exp, keep, odif, pvals, qvals):
+def _new_experiment_from_pvals(cexp, exp, keep, odif, pvals, qvals) -> Experiment:
     '''Combine the pvalues and effect size into a new experiment.
 
     Keep only the significant features, sort the features by the effect size

--- a/calour/experiment.py
+++ b/calour/experiment.py
@@ -119,7 +119,7 @@ class Experiment:
                     'sample_metadata_md5': get_dataframe_md5(self.sample_metadata),
                     'feature_metadata_file': 'NA',
                     'feature_metadata_md5': get_dataframe_md5(self.feature_metadata)}
-        self.info = {} if info is None else info
+        self.info = info
 
     def validate(self):
         '''Validate the Experiment object.

--- a/calour/experiment.py
+++ b/calour/experiment.py
@@ -30,7 +30,7 @@ import pandas as pd
 import numpy as np
 import scipy.sparse
 
-from .util import _convert_axis_name
+from .util import _convert_axis_name, get_dataframe_md5, get_data_md5
 
 logger = getLogger(__name__)
 
@@ -96,7 +96,6 @@ class Experiment:
             feature_metadata = pd.DataFrame(np.arange(data.shape[1]))
         self.feature_metadata = feature_metadata
         self.validate()
-        self.info = {} if info is None else info
         self.description = description
         self.normalized = 0
         # the function calling history list
@@ -111,6 +110,16 @@ class Experiment:
         self.databases = defaultdict(dict)
         for cdatabase in databases:
             self.databases[cdatabase] = {}
+
+        # set the data and metadata md5 if not provided
+        if info is None:
+            info = {'data_file': 'NA',
+                    'data_md5': get_data_md5(self.data),
+                    'sample_metadata_file': 'NA',
+                    'sample_metadata_md5': get_dataframe_md5(self.sample_metadata),
+                    'feature_metadata_file': 'NA',
+                    'feature_metadata_md5': get_dataframe_md5(self.feature_metadata)}
+        self.info = {} if info is None else info
 
     def validate(self):
         '''Validate the Experiment object.

--- a/calour/filtering.py
+++ b/calour/filtering.py
@@ -96,7 +96,7 @@ def downsample(exp: Experiment, field, axis=0, keep=None,
     return exp.reorder(keep, axis=axis, inplace=inplace)
 
 
-def _balanced_subsample(x, n=None, random_seed=None):
+def _balanced_subsample(x, n=None, random_seed=None) -> np.ndarray:
     '''subsample the array to have equal number count for each unique values.
 
     Parameters
@@ -386,7 +386,7 @@ def is_prevalent(data, axis, cutoff=1, fraction=0.1):
     return res
 
 
-def freq_ratio(data, axis, ratio=19):
+def freq_ratio(data, axis, ratio=19) -> np.ndarray:
     '''Check if frequency ratios is not too big.
 
     Frequency ratio is defined as the frequency of the most prevalent
@@ -427,7 +427,7 @@ def freq_ratio(data, axis, ratio=19):
 
     '''
     if issparse(data):
-        res = np.ones(data.shape[1-axis], dtype='?')
+        res = np.ones(data.shape[1 - axis], dtype='?')
         if axis == 0:
             data = data.T
         for i, x in enumerate(data):

--- a/calour/heatmap/heatmap.py
+++ b/calour/heatmap/heatmap.py
@@ -170,7 +170,7 @@ def heatmap(exp: Experiment, sample_field=None, feature_field=None,
             xticklabel_len=16, yticklabel_len=16,
             xticks_max=10, yticks_max=30,
             norm=None, clim=(None, None), cmap='viridis',
-            rect=None, cax=None, ax=None, bad_color='black'):
+            rect=None, cax=None, ax=None, bad_color='black') -> mpl.axes.Axes:
     '''Plot a heatmap for the experiment.
 
     Plot a heatmap for the :attr:`.Experiment.data` with features in row

--- a/calour/heatmap/heatmap.py
+++ b/calour/heatmap/heatmap.py
@@ -13,6 +13,8 @@ import copy
 
 import matplotlib as mpl
 import matplotlib.patches as mpatches
+import matplotlib.axes
+import matplotlib.figure
 import numpy as np
 
 from .. import Experiment

--- a/calour/heatmap/plotgui.py
+++ b/calour/heatmap/plotgui.py
@@ -402,11 +402,11 @@ class PlotGUI(ABC):
     def clear_selection(self):
         '''Delete all shown selection lines '''
         for cline in self.selected_samples.values():
-            self.ax_hm.lines.remove(cline)
+            cline.remove()
             logger.debug('remove sample selection %r' % cline)
         self.selected_samples = {}
         for cline in self.selected_features.values():
-            self.ax_hm.lines.remove(cline)
+            cline.remove()
             logger.debug('remove sample selection %r' % cline)
         self.selected_features = {}
 
@@ -430,7 +430,7 @@ class PlotGUI(ABC):
                 logger.debug('add sample selection %r' % cpos)
             else:
                 if toggle:
-                    self.ax_hm.lines.remove(self.selected_samples[cpos])
+                    self.selected_samples[cpos].remove()
                     del self.selected_samples[cpos]
         for cpos in featurepos:
             if cpos not in self.selected_features:
@@ -439,7 +439,7 @@ class PlotGUI(ABC):
                 logger.debug('add sample selection %r' % cpos)
             else:
                 if toggle:
-                    self.ax_hm.lines.remove(self.selected_features[cpos])
+                    self.selected_features[cpos].remove()
                     del self.selected_features[cpos]
         self.figure.canvas.draw()
 

--- a/calour/io.py
+++ b/calour/io.py
@@ -108,7 +108,7 @@ def _read_qiime2_zip(fp, sample_in_row=False):
     return sid, fid, data, fmd
 
 
-def read_qiime2(fp, sample_metadata_file=None, rep_seq_file=None, taxonomy_file=None, **kwargs):
+def read_qiime2(fp, sample_metadata_file=None, rep_seq_file=None, taxonomy_file=None, **kwargs) -> Experiment:
     '''Read a qiime2 artifact files into an amplicon experiment.
 
 
@@ -350,7 +350,7 @@ def read(data_file, sample_metadata_file=None, feature_metadata_file=None,
          sample_id_proc=None, feature_id_proc=None,
          sample_metadata_kwargs=None, feature_metadata_kwargs=None,
          cls=Experiment,
-         *, normalize):
+         *, normalize) -> Experiment:
     '''Read in an experiment.
 
     .. note:: The order in the sample and feature metadata tables are changed
@@ -485,7 +485,7 @@ def read(data_file, sample_metadata_file=None, feature_metadata_file=None,
 
 @ds.with_indent(4)
 def read_amplicon(data_file, sample_metadata_file=None,
-                  *, min_reads, normalize, **kwargs):
+                  *, min_reads, normalize, **kwargs) -> AmpliconExperiment:
     '''Read in an amplicon experiment.
 
     This wraps :func:`read`.
@@ -536,7 +536,7 @@ def read_ms(data_file, sample_metadata_file=None, feature_metadata_file=None, gn
             data_file_type='mzmine2', sample_in_row=None, direct_ids=None, get_mz_rt_from_feature_id=None,
             use_gnps_id_from_AllFiles=True, cut_sample_id_sep=None,
             mz_rt_sep=None, mz_thresh=0.02, rt_thresh=15,
-            description=None, sparse=False, *, normalize, **kwargs):
+            description=None, sparse=False, *, normalize, **kwargs) -> MS1Experiment:
     '''Read a mass-spec experiment.
 
     Calour supports various ms table formats, with several preset formats (specified by the data_file_type='XXX' parameter),

--- a/calour/plotting.py
+++ b/calour/plotting.py
@@ -28,6 +28,7 @@ Functions
 
 from logging import getLogger
 from itertools import cycle, combinations
+from typing import Tuple
 
 import numpy as np
 import matplotlib as mpl
@@ -76,7 +77,7 @@ def plot_hist(exp: Experiment, ax=None, **kwargs):
     return counts, bins, ax
 
 
-def plot_enrichment(exp: Experiment, enriched, max_show=10, max_len=40, ax=None, labels=('group1', 'group2'), colors=('green', 'red'), labels_kwargs={'style': 'italic', 'weight': 'semibold'}, numbers_kwargs={'color': 'white', 'weight': 'bold'}):
+def plot_enrichment(exp: Experiment, enriched, max_show=10, max_len=40, ax=None, labels=('group1', 'group2'), colors=('green', 'red'), labels_kwargs={'style': 'italic', 'weight': 'semibold'}, numbers_kwargs={'color': 'white', 'weight': 'bold'}) -> mpl.axes.Axes:
     '''Plot a horizontal bar plot for enriched terms
 
     Parameters
@@ -171,7 +172,7 @@ def plot_enrichment(exp: Experiment, enriched, max_show=10, max_len=40, ax=None,
     return ax
 
 
-def plot_diff_abundance_enrichment(exp: Experiment, max_show=10, max_len=40, ax=None, colors=('green', 'red'), show_legend=True, labels_kwargs={'style': 'italic', 'weight': 'semibold'}, numbers_kwargs={'color': 'white', 'weight': 'bold'}, **kwargs):
+def plot_diff_abundance_enrichment(exp: Experiment, max_show=10, max_len=40, ax=None, colors=('green', 'red'), show_legend=True, labels_kwargs={'style': 'italic', 'weight': 'semibold'}, numbers_kwargs={'color': 'white', 'weight': 'bold'}, **kwargs) -> Tuple[mpl.axes.Axes, Experiment]:
     '''Plot the term enrichment of differentially abundant bacteria
 
     Parameters
@@ -242,7 +243,7 @@ def plot_diff_abundance_enrichment(exp: Experiment, max_show=10, max_len=40, ax=
     return ax2, newexp
 
 
-def plot_core_features(exp: Experiment, field=None, steps=None, cutoff=2, frac=0.9, iterations=10, alpha=0.5, linewidth=0.7, ax=None):
+def plot_core_features(exp: Experiment, field=None, steps=None, cutoff=2, frac=0.9, iterations=10, alpha=0.5, linewidth=0.7, ax=None) -> mpl.axes.Axes:
     '''Plot the percentage of core features shared in increasing number of samples.
 
     To see if there is a core feature set shared across most of the samples.
@@ -315,7 +316,7 @@ def plot_core_features(exp: Experiment, field=None, steps=None, cutoff=2, frac=0
     return ax
 
 
-def _compute_frac_nonzero(data, steps=None, cutoff=2, frac=0.9, random_seed=None):
+def _compute_frac_nonzero(data, steps=None, cutoff=2, frac=0.9, random_seed=None) -> np.ndarray:
     '''iteratively compute the fraction of non-zeros in each column after subsampling rows.
 
     Parameters
@@ -369,7 +370,7 @@ def _compute_frac_nonzero(data, steps=None, cutoff=2, frac=0.9, random_seed=None
     return shared
 
 
-def plot_abund_prevalence(exp: Experiment, field, log=True, min_abund=0.01, alpha=0.5, linewidth=0.7, ax=None):
+def plot_abund_prevalence(exp: Experiment, field, log=True, min_abund=0.01, alpha=0.5, linewidth=0.7, ax=None) -> mpl.axes.Axes:
     '''Plot abundance against prevalence.
 
     Prevalence/abundance curve is a chart used to visualize the
@@ -440,7 +441,7 @@ def plot_stacked_bar(exp: Experiment, field=None, sample_color_bars=None,
                      color_bar_label=True,
                      barx_label_kwargs=None, barx_width=0.3, barx_colors=None,
                      title=None, figsize=(12, 8), legend_size='small',
-                     xtick=False, cmap='Paired'):
+                     xtick=False, cmap='Paired') -> mpl.figure.Figure:
     '''Plot the stacked bar for feature abundances.
 
     Parameters
@@ -548,7 +549,7 @@ def plot_stacked_bar(exp: Experiment, field=None, sample_color_bars=None,
 
 def plot_feature_matrix(exp: Experiment, fields, feature_ids, title_field=None,
                         transform_x=None, transform_y=None, plot='scatter',
-                        ncols=5, nrows=None, size=2, aspect=1, **kwargs):
+                        ncols=5, nrows=None, size=2, aspect=1, **kwargs) -> mpl.figure.Figure:
     '''This plots an array of scatter plots between each features against the specified sample metadata.
 
     For each panel of scatter plot, the x-axis is the co-variates
@@ -616,7 +617,7 @@ def plot_feature_matrix(exp: Experiment, fields, feature_ids, title_field=None,
     return fig
 
 
-def plot_box(x, y, title='', ax=None, **kwargs):
+def plot_box(x, y, title='', ax=None, **kwargs) -> mpl.axes.Axes:
     '''Plot box plot.
 
     Parameters
@@ -662,7 +663,7 @@ def plot_box(x, y, title='', ax=None, **kwargs):
     return ax
 
 
-def plot_scatter(x, y, title='', ax=None, **kwargs):
+def plot_scatter(x, y, title='', ax=None, **kwargs) -> mpl.axes.Axes:
     '''Plot scatter plot.
 
     Parameters

--- a/calour/transforming.py
+++ b/calour/transforming.py
@@ -66,7 +66,7 @@ def normalize(exp: Experiment, total=10000, axis=0, inplace=False) -> Experiment
         raise ValueError('Normalization total (%s) must be positive' % total)
     if not inplace:
         exp = deepcopy(exp)
-    exp.data = preprocessing.normalize(exp.data, norm='l1', axis=1-axis) * total
+    exp.data = preprocessing.normalize(exp.data, norm='l1', axis=1 - axis) * total
     # store the normalization depth into the experiment metadata
     exp.normalized = total
     return exp
@@ -176,7 +176,7 @@ def rescale(exp: Experiment, total=10000, axis=0, inplace=False) -> Experiment:
     '''
     if not inplace:
         exp = deepcopy(exp)
-    current_mean = np.mean(exp.data.sum(axis=1-axis))
+    current_mean = np.mean(exp.data.sum(axis=1 - axis))
     exp.data = exp.data * total / current_mean
     return exp
 
@@ -204,7 +204,7 @@ def standardize(exp: Experiment, axis=0, inplace=False) -> Experiment:
         exp = deepcopy(exp)
     if exp.sparse:
         exp.sparse = False
-    preprocessing.scale(exp.data, axis=1-axis, copy=False)
+    preprocessing.scale(exp.data, axis=1 - axis, copy=False)
     return exp
 
 
@@ -285,7 +285,7 @@ def permute_data(exp: Experiment, normalize=True, inplace=False, random_seed=Non
     return exp
 
 
-def center_log_ratio(exp: Experiment, method=lambda matrix: matrix + 1, centralize=False, inplace=False):
+def center_log_ratio(exp: Experiment, method=lambda matrix: matrix + 1, centralize=False, inplace=False) -> Experiment:
     """ Performs a clr transform to each sample.
 
     Parameters
@@ -322,7 +322,7 @@ def center_log_ratio(exp: Experiment, method=lambda matrix: matrix + 1, centrali
     return exp
 
 
-def subsample_count(exp: Experiment, total, replace=False, inplace=False, random_seed=None):
+def subsample_count(exp: Experiment, total, replace=False, inplace=False, random_seed=None) -> Experiment:
     """Randomly subsample each sample to the same number of counts.
 
     .. warning:: This function will change the :attr:`Experiment.data`

--- a/calour/util.py
+++ b/calour/util.py
@@ -39,6 +39,7 @@ from pkg_resources import resource_filename
 
 import numpy as np
 import scipy
+from pandas.util import hash_pandas_object
 
 
 logger = getLogger(__name__)
@@ -317,6 +318,29 @@ def get_data_md5(data):
     datmd5 = hashlib.md5(data.tobytes())
     datmd5 = datmd5.hexdigest()
     logger.debug('data md5 is: %s' % datmd5)
+    return datmd5
+
+
+def get_dataframe_md5(df):
+    '''get the md5 of the text file.
+
+    Parameters
+    ----------
+    df : pandas.Dataframe
+        The dataframe to encode
+    encoding : str or None, optional
+        encoding of the text file (see python str.encode() ). None to use 'utf-8'
+
+    Returns
+    -------
+    md5: str
+        the md5 of the dataframe
+    '''
+    if df is None:
+        return None
+    logger.debug('getting dataframe md5 for %d rows' % len(df))
+    datmd5 = hashlib.md5(hash_pandas_object(df).values)
+    datmd5 = datmd5.hexdigest()
     return datmd5
 
 


### PR DESCRIPTION
* Add type hints to methods
* Bugfix - fix the interactive heatmap so will work with matplotlib > 3.7 (problem with Axes.lines.remove in mpl3.7)
* Add md5 hash for the sample metadata dataframe if Experiment created from dataframes