### PR TITLE
Small Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # calour changelog
 
+## Version 2024.8.29
+New Features:
+* Support lists for sample_metadata and feature_metadata in Experiment.__init__()
+
+Bug Fixes:
+* Raise error when plotting a heatmap for an empty experiment
+
 ## Version 2024.5.30
 add mRNAExperiment class for handling rna-seq data. interactive heatmap gene information is via the rna_calour module using Harmonizome server (https://maayanlab.cloud/Harmonizome)
 

--- a/calour/__init__.py
+++ b/calour/__init__.py
@@ -19,7 +19,7 @@ from .util import set_log_level, register_functions
 
 
 __credits__ = "https://github.com/biocore/calour/graphs/contributors"
-__version__ = "2024.5.30"
+__version__ = "2024.8.29"
 
 __all__ = ['read', 'read_amplicon', 'read_ms', 'read_qiime2',
            'Experiment', 'AmpliconExperiment', 'MS1Experiment','mRNAExperiment',

--- a/calour/experiment.py
+++ b/calour/experiment.py
@@ -64,9 +64,9 @@ class Experiment:
     data : numpy.ndarray or scipy.sparse.csr_matrix
         The abundance table for OTUs, metabolites, genes, etc. Samples
         are in row and features in column
-    sample_metadata : pandas.DataFrame
+    sample_metadata : pandas.DataFrame or list
         The metadata on the samples
-    feature_metadata : pandas.DataFrame
+    feature_metadata : pandas.DataFrame or list
         The metadata on the features
     shape : tuple of (int, int)
         the dimension of data
@@ -91,6 +91,16 @@ class Experiment:
     def __init__(self, data, sample_metadata, feature_metadata=None, databases=(),
                  info=None, description='', sparse=True):
         self.data = data
+
+        if isinstance(sample_metadata, list):
+            sample_metadata=pd.DataFrame(index=sample_metadata)
+        if isinstance(feature_metadata, list):
+            feature_metadata=pd.DataFrame(index=feature_metadata)
+        if 'SampleID' not in sample_metadata.columns:
+            sample_metadata['SampleID']=sample_metadata.index.values
+        if '_feature_id' not in feature_metadata.columns:
+            feature_metadata['_feature_id']=feature_metadata.index.values
+
         self.sample_metadata = sample_metadata
         if feature_metadata is None:
             feature_metadata = pd.DataFrame(np.arange(data.shape[1]))

--- a/calour/heatmap/heatmap.py
+++ b/calour/heatmap/heatmap.py
@@ -292,6 +292,9 @@ def heatmap(exp: Experiment, sample_field=None, feature_field=None,
     data = exp.get_data(sparse=False)
     numrows, numcols = exp.shape
 
+    if numrows == 0 or numcols == 0:
+        raise ValueError('Experiment has no data to plot')
+
     if ax is None:
         fig, ax = plt.subplots()
     else:


### PR DESCRIPTION
* add support for supplying lists (of sample/feature IDs) instead of pd.DataFrame to Experiment.__init__(). Useful since otherwise need to create a Dataframe with index and appropriate field ('SampleID' or '_feature_id') in order to work.
* Raise an error when plotting an empty Experiment (otherwise raises an error downstream when trying to get the vmin/vmax).