### PR TITLE
add filter_zeros parameter to analysis functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # calour changelog
+## Version 2024.9.29
+New features:
+* Add filter_zeros parameter to analysis functions (correlation, diff_abundance) to enable working with data containing negative values (such as log-ratios)
 
 ## Version 2024.5.30
 add mRNAExperiment class for handling rna-seq data. interactive heatmap gene information is via the rna_calour module using Harmonizome server (https://maayanlab.cloud/Harmonizome)

--- a/calour/__init__.py
+++ b/calour/__init__.py
@@ -19,7 +19,7 @@ from .util import set_log_level, register_functions
 
 
 __credits__ = "https://github.com/biocore/calour/graphs/contributors"
-__version__ = "2024.5.30"
+__version__ = "2024.9.29"
 
 __all__ = ['read', 'read_amplicon', 'read_ms', 'read_qiime2',
            'Experiment', 'AmpliconExperiment', 'MS1Experiment','mRNAExperiment',


### PR DESCRIPTION
add filter_zeros parameter to correlation, diff_abunadnce.
Default is True (to remove features with sum<=0) so you do less multiple hypothesis corrections
Now can supply filter_zeros=False to skip this filtering step - useful when dealing with data that contains negatives (such as log-ratios in a RatioExperiment)

Also updated docsctring